### PR TITLE
Change dependabot interval to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: "docker"
     directory: "/scripts/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   # Configuration for pyproj
   - package-ecosystem: "pip"


### PR DESCRIPTION
Checking daily is not worth it.
To run it manually when a new docker image is released, go to "Insights, Dependency graph, Dependabot, scripts/Dockerfile" and click "Check for updates"